### PR TITLE
Return empty string when value is None

### DIFF
--- a/flask_humanize/__init__.py
+++ b/flask_humanize/__init__.py
@@ -140,6 +140,9 @@ class Humanize(object):
         return response
 
     def _humanize(self, value, fname='naturaltime', **kwargs):
+        if value is None:
+            return ''
+
         try:
             method = getattr(humanize, fname)
         except AttributeError:


### PR DESCRIPTION
Hi Vital, thank you for your job. This project is really useful.

In _humanize, AttributeError occurs when value parameter is None.
This fixes the problem by returning empty string when value is None.

Thank you.