### PR TITLE
Replace getfuncargvalue with getfixturevalue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,5 @@ def h(request):
     if 'app' not in request.fixturenames:
         return
 
-    app = request.getfuncargvalue('app')
+    app = request.getfixturevalue('app')
     return Humanize(app)


### PR DESCRIPTION
There is not getfuncargvalue  function starting from pytest 5.1.

https://github.com/pytest-dev/pytest/issues/5180